### PR TITLE
Add js install script to allow depending on rebel-bin in package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+tmp

--- a/install.js
+++ b/install.js
@@ -1,0 +1,39 @@
+var unzip = require('unzip');
+var fs = require('fs');
+var http = require('http');
+var childProcess = require('child_process');
+var path = require('path');
+
+var folderName;
+if (process.platform === "darwin") {
+  folderName = "osx";
+} else if (process.platform === "win32") {
+  console.error("Windows not supported yet");
+  return;
+} else {
+  folderName = "linux64";
+  pathToFile = path.join("linux64", "rebel-linux64.zip");
+}
+
+  fs.mkdir('tmp', function() {
+    var tmpFolder = path.join(__dirname, 'tmp');
+    var unzipExtractor = unzip.Extract({ path: tmpFolder});
+    unzipExtractor.on('error', function(err) {
+      throw err;
+    });
+    unzipExtractor.on('close', function(){
+      var target = path.resolve(__dirname, "tmp", "src", "rebel");      
+      fs.chmod(target, '777', function(err, stdout, stderr){
+        if (err) {
+          console.log("Error changing permissions on configure file:", err);
+          return;
+        }
+        console.log(stdout);
+        var destination = path.resolve(__dirname, "..", ".bin", "rebel");
+        // ../.bin/rebel -> tmp/src/rebel
+        fs.symlink(target, destination, function(){ console.log("Done installing rebel."); });
+      });
+    });   
+    var readStream = fs.createReadStream(path.join(folderName, "rebel-" + folderName + ".zip"));
+    readStream.pipe(unzipExtractor);
+  });

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dependency-env": "https://github.com/npm-ml/dependency-env.git",
     "ocamlBetterErrors": "0.0.10",
     "nopam": "https://github.com/yunxing/nopam.git",
-    "reason": "https://github.com/facebook/reason.git"
+    "reason": "https://github.com/facebook/reason.git",
+    "bs-platform": "https://github.com/bloomberg/bucklescript.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": ""
+    "postinstall": "node install.js"
   },
   "repository": {
     "type": "git",
@@ -16,5 +16,12 @@
   "bugs": {
     "url": "https://github.com/vramana/rebel-bin/issues"
   },
-  "homepage": "https://github.com/vramana/rebel-bin#readme"
+  "homepage": "https://github.com/vramana/rebel-bin#readme",
+  "dependencies": {
+    "unzip": "^0.1.11",
+    "dependency-env": "https://github.com/npm-ml/dependency-env.git",
+    "ocamlBetterErrors": "0.0.10",
+    "nopam": "https://github.com/yunxing/nopam.git",
+    "reason": "https://github.com/facebook/reason.git"
+  }
 }


### PR DESCRIPTION
This makes depending on `rebel-bin` a viable alternative to depending on `rebel`.